### PR TITLE
fix(html-lang): added defined lang for the web document

### DIFF
--- a/dialog/index.html
+++ b/dialog/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 
 <head>
     <meta charset='utf-8'>


### PR DESCRIPTION
### Related Issue or bug
Language popup appearing for Dialog section 

Fixes: https://github.com/atapas/html-tips-tricks/issues/8

### Proposed Changes
- Added defined html language to prevent automatic detection of language
- Prevented the browser language prompt for users by choosing 'english', as the default language was being picked as 'dutch'