### PR TITLE
hacktoberfest2022 tooltip

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,6 +91,9 @@
                 <a href='./lazy-loading/index.html'>
                     Lazy Loading</a> - Lazy Load html images natively
             </li>
+            <li>
+                <a href="./tooltip/index.html">Tooltip</a> - Tootltip using title attribute
+            </li>
         </ul>
     </div>
 </body>

--- a/main.css
+++ b/main.css
@@ -75,3 +75,9 @@ dialog::backdrop {
   );
   backdrop-filter: blur(3px);
 }
+
+#img-tooltip{
+  background-color: wheat;
+  width:30%;
+  height:30%;
+}

--- a/tooltip/index.html
+++ b/tooltip/index.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset='utf-8'>
+    <meta http-equiv='X-UA-Compatible' content='IE=edge'>
+    <title>HTML Tips and Tricks - Title attribute tooltip</title>
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
+    <link rel="apple-touch-icon" sizes="57x57" href="../favicons/apple-icon-57x57.png">
+    <link rel="apple-touch-icon" sizes="60x60" href="../favicons/apple-icon-60x60.png">
+    <link rel="apple-touch-icon" sizes="72x72" href="../favicons/apple-icon-72x72.png">
+    <link rel="apple-touch-icon" sizes="76x76" href="../favicons/apple-icon-76x76.png">
+    <link rel="apple-touch-icon" sizes="114x114" href="../favicons/apple-icon-114x114.png">
+    <link rel="apple-touch-icon" sizes="120x120" href="../favicons/apple-icon-120x120.png">
+    <link rel="apple-touch-icon" sizes="144x144" href="../favicons/apple-icon-144x144.png">
+    <link rel="apple-touch-icon" sizes="152x152" href="../favicons/apple-icon-152x152.png">
+    <link rel="apple-touch-icon" sizes="180x180" href="../favicons/apple-icon-180x180.png">
+    <link rel="icon" type="image/png" sizes="192x192" href="../favicons/android-icon-192x192.png">
+    <link rel="icon" type="image/png" sizes="32x32" href="../favicons/favicon-32x32.png">
+    <link rel="icon" type="image/png" sizes="96x96" href="../favicons/favicon-96x96.png">
+    <link rel="icon" type="image/png" sizes="16x16" href="../favicons/favicon-16x16.png">
+    <link rel="manifest" href="../favicons/manifest.json">
+    <meta name="msapplication-TileColor" content="#ffffff">
+    <meta name="msapplication-TileImage" content="../favicons/ms-icon-144x144.png">
+    <meta name='viewport' content='width=device-width, initial-scale=1'>
+    <link href="https://fonts.googleapis.com/css2?family=Chilanka&display=swap" rel="stylesheet">
+    <link rel='stylesheet' type='text/css' media='screen' href='../main.css'>
+</head>
+
+<body>
+    <div class="demo">
+        <a href="../index.html" class="home">
+          <img src="../home.svg" alt="home" />
+        </a>
+        <h1>Tooltip using title attribute</h1>
+        <p>Hover over the below items for few seconds to see the tooltip feature
+        -The tooltip feature has been implemented using only the title attribute and no css</p>
+        <h1 title="tooltip-1 in h1 tag"> Hover over this header</h1>
+        <p title="tooltip-2 in p tag">Hover over this paragraph.</p>
+        <br>
+        <div>Hover over the below the image</div>
+        <img src="../html5.png" alt="html5" title="tooltip-3 in an image" id="img-tooltip">
+        <br> <br>
+        <a href="https://github.com/atapas" title="tooltip-4 in a tag">Hover over this github profile link</a>
+    </div>
+        
+</body>
+
+</html>


### PR DESCRIPTION
@atapas 
- most people use css to add tooltip.
- here, I've simply demonstrated the use of title attribute ( no css ) to implement tooltip in 4 tags- `<h1>`, `<p>` , `<img>` and `<a>`. Since, this is a html-tips-tricks repo, this might be an useful feature
- the issue created by me is #43 
- I've tried to retain the same styling in my page and also added the favicon in my index.html
- do add the hacktoberfest-accepted tag if no issues are found.
- Mention the issues if found any for correction.
I want ro resolve #43.
 